### PR TITLE
want debug-focused quick option for build-illumos

### DIFF
--- a/tools/helios-build/src/main.rs
+++ b/tools/helios-build/src/main.rs
@@ -623,6 +623,7 @@ fn cmd_illumos_genenv(ca: &CommandArg) -> Result<()> {
     };
 
     regen_illumos_sh(ca.log, &gate, BuildType::Quick)?;
+    regen_illumos_sh(ca.log, &gate, BuildType::QuickDebug)?;
     regen_illumos_sh(ca.log, &gate, BuildType::Full)?;
 
     info!(ca.log, "ok");
@@ -1693,6 +1694,7 @@ fn cmd_setup(ca: &CommandArg) -> Result<()> {
 
     let gate = top_path(&["projects", "illumos"])?;
     regen_illumos_sh(log, &gate, BuildType::Full)?;
+    regen_illumos_sh(log, &gate, BuildType::QuickDebug)?;
     regen_illumos_sh(log, &gate, BuildType::Quick)?;
 
     /*


### PR DESCRIPTION
This allows one to do an initial debug build, which generally is pretty helpful for development purposes and I'd like to use this as part of streamlining the stlouis builds. This adds a `-d` option to `build-illumos` that requires (at this point) the `-q` for quick build. Here's the relevant output from trying to use this:

```
rm@beowulf:/ws/rm/stlouis-helios$ ./helios-build build-illumos --help
Usage: helios [OPTIONS] build-illumos [OPTIONS]

Options:
        --help          usage information
    -q, --quick         quick build (no shadows, no DEBUG)
    -d, --debug         build a debug build (use with -q)

rm@beowulf:/ws/rm/stlouis-helios$ ./helios-build build-illumos -d
Error: requesting a debug build (-d) requires -q
```

This shows us using the correct environment file for the different types of builds:

```
rm@beowulf:/ws/rm/stlouis-helios$ ./helios-build build-illumos -q
Jan 22 19:34:21.589 INFO file /ws/rm/stlouis-helios/projects/illumos/illumos-quick.sh exists, with correct contents
Jan 22 19:34:21.589 INFO ok!
Jan 22 19:34:21.589 INFO exec: ["/sbin/sh", "-c", "cd /ws/rm/stlouis-helios/projects/illumos && ./usr/src/tools/scripts/nightly /ws/rm/stlouis-helios/projects/illumos/illumos-quick.sh"]
^C
rm@beowulf:/ws/rm/stlouis-helios$ ./helios-build build-illumos 
Jan 22 19:34:24.426 INFO file /ws/rm/stlouis-helios/projects/illumos/illumos.sh exists, with correct contents
Jan 22 19:34:24.427 INFO ok!
Jan 22 19:34:24.427 INFO exec: ["/sbin/sh", "-c", "cd /ws/rm/stlouis-helios/projects/illumos && ./usr/src/tools/scripts/nightly /ws/rm/stlouis-helios/projects/illumos/illumos.sh"]
^^R 
^C
rm@beowulf:/ws/rm/stlouis-helios$ ./helios-build build-illumos -qd
Jan 22 19:34:28.152 INFO file /ws/rm/stlouis-helios/projects/illumos/illumos-quick-debug.sh exists, with correct contents
Jan 22 19:34:28.153 INFO ok!
Jan 22 19:34:28.153 INFO exec: ["/sbin/sh", "-c", "cd /ws/rm/stlouis-helios/projects/illumos && ./usr/src/tools/scripts/nightly /ws/rm/stlouis-helios/projects/illumos/illumos-quick-debug.sh"]
```

Here are the differences between the illumos-quick.sh and the illumos-quick-debug.sh:

```
$ diff -u illumos-quick.sh illumos-quick-debug.sh 
--- illumos-quick.sh    Fri Jan 21 02:16:51 2022
+++ illumos-quick-debug.sh      Sat Jan 22 19:30:01 2022
@@ -1,4 +1,4 @@
-export NIGHTLY_OPTIONS='-nCAmprt'
+export NIGHTLY_OPTIONS='-nCADFmprt'
 export CODEMGR_WS='/ws/rm/stlouis-helios/projects/illumos'
 export MACH="$(uname -p)"
 export GNUC_ROOT=/opt/gcc-7
```