### PR TITLE
Add sled-agent and maghemite to ZFS image, autoboot sled agent

### DIFF
--- a/image/templates/gimlet/zfs.json
+++ b/image/templates/gimlet/zfs.json
@@ -77,6 +77,19 @@
             "src": "mfg.xml",
             "owner": "root", "group": "sys", "mode": "0644" },
 
+        { "t": "ensure_dir",
+            "dir": "/opt/oxide/sled-agent",
+            "extsrc": "sled-agent",
+            "owner": "root", "group": "sys", "mode": "0644" },
+        { "t": "ensure_dir",
+            "dir": "/opt/oxide/mg-ddm",
+            "extsrc": "mg-ddm",
+            "owner": "root", "group": "sys", "mode": "0644" },
+        { "t": "ensure_file", "with": "mfg",
+            "file": "/lib/svc/manifest/site/sled-agent.xml",
+            "extsrc": "sled-agent/pkg/manifest.xml",
+            "owner": "root", "group": "sys", "mode": "0644" },
+
         { "t": "include", "name": "smf-reduce" },
         { "t": "seed_smf", "apply_site": true, "skip_seed": true }
     ]


### PR DESCRIPTION
WARNING: Depends on...
- https://github.com/oxidecomputer/omicron/pull/2475 (To package global zone services)
- https://github.com/oxidecomputer/helios/pull/56 (To download and unpack global zone services)
- https://github.com/illumos/image-builder/pull/4  (For `ensure_dir` pulling in a whole directory)
