### PR TITLE
image: Specify explicit SPI mode.

### DIFF
--- a/image/amd/milan-gimlet-b.efs.json5
+++ b/image/amd/milan-gimlet-b.efs.json5
@@ -1,5 +1,10 @@
 {
 	processor_generation: "Milan",
+	spi_mode_zen_rome: {
+		fast_speed_new: "16.66 MHz",
+		read_mode: "Normal up to 33.33 MHz",
+		micron_mode: "SupportMicron"
+	},
 	psp: {
 		PspDirectory: {
 			entries: [


### PR DESCRIPTION
Fixes <https://github.com/oxidecomputer/helios/issues/73>.

Could be nicer after https://github.com/oxidecomputer/amd-efs/pull/65 is merged.

Successfully tested on b9.

Should still be tested on c43 as well (I have no idea how to get to that machine).