### PR TITLE
image: AMD firmware 1.0.0.a; Disable BMC.

### DIFF
--- a/image/amd/milan-gimlet-b.efs.json5
+++ b/image/amd/milan-gimlet-b.efs.json5
@@ -3921,7 +3921,7 @@
 										},
 										{
 											Byte: {
-												BmcEndLane: 0x81
+												BmcEndLane: 0xFF
 											}
 										},
 										{
@@ -4139,7 +4139,7 @@
 										},
 										{
 											Byte: {
-												BmcSocket: 0x00
+												BmcSocket: 0x0F
 											}
 										},
 										{
@@ -4229,7 +4229,7 @@
 										},
 										{
 											Byte: {
-												BmcStartLane: 0x81
+												BmcStartLane: 0xFF
 											}
 										},
 										{


### PR DESCRIPTION
oxidecomputer/helios#64 APCB configuration should not include BMC early link training