### PR TITLE
illumos: explicitly add 'e' to MAKEFLAGS

### DIFF
--- a/tools/helios-build/src/main.rs
+++ b/tools/helios-build/src/main.rs
@@ -518,7 +518,7 @@ fn regen_illumos_sh<P: AsRef<Path>>(log: &Logger, gate: P, bt: BuildType)
     env += "export ATLOG=\"$CODEMGR_WS/log\"\n";
     env += "export LOGFILE=\"$ATLOG/nightly.log\"\n";
     env += "export BUILD_TOOLS='/opt'\n";
-    env += "export MAKEFLAGS='k'\n";
+    env += "export MAKEFLAGS='ke'\n";
     env += "export PARENT_WS=''\n";
     env += "export REF_PROTO_LIST=\"$PARENT_WS/usr/src/proto_list_${MACH}\"\n";
     env += "export PARENT_ROOT=\"$PARENT_WS/proto/root_$MACH\"\n";


### PR DESCRIPTION
Following the integration of [15655 Build scripts should tolerate make -w](https://www.illumos.org/issues/15655), a bldenv no longer overwrites the provided MAKEFLAGS.

I've opened https://www.illumos.org/issues/15663 for this regression (people either need to update their .env files or remember to always use `-e` for make in a bldenv), but we can fix this for people using helios.

Otherwise, almost everything breaks, including overriding things like `PRIMARY_CC` from Makefile.master.

A simple example:

```
Build type   is  DEBUG
RELEASE      is
VERSION      is helios-1.0.21962
RELEASE_DATE is May 2023

The top-level 'setup' target is available to build headers and tools.

Using /usr/bin/zsh as shell.
/home/andy/helios/projects/illumos
atrium:illumos:stlouis% dmake -C usr/src cscope.out
/ws/onnv-tools/onbld/bin/xref -f -x cscope.out
sh: /ws/onnv-tools/onbld/bin/xref: not found [No such file or directory]
*** Error code 127
dmake: Warning: Target `cscope.out' not remade because of errors
Current working directory /home/andy/helios/projects/illumos/usr/src
```