### PR TITLE
intel_nhmex, other closed mods should not be shipped

### DIFF
--- a/image/mkcpio.sh
+++ b/image/mkcpio.sh
@@ -59,7 +59,6 @@ kernel/drv/amd64/ixgbe
 kernel/drv/amd64/kmdb
 kernel/drv/amd64/lofi
 kernel/drv/amd64/log
-kernel/drv/amd64/mc-amd
 kernel/drv/amd64/mm
 kernel/drv/amd64/nulldriver
 kernel/drv/amd64/nvme
@@ -105,7 +104,6 @@ kernel/drv/kmdb.conf
 kernel/drv/llc1.conf
 kernel/drv/lofi.conf
 kernel/drv/log.conf
-kernel/drv/mc-amd.conf
 kernel/drv/mm.conf
 kernel/drv/nvme.conf
 kernel/drv/openeepr.conf

--- a/image/templates/gimlet/ramdisk-02-trim.json
+++ b/image/templates/gimlet/ramdisk-02-trim.json
@@ -59,6 +59,10 @@
         { "t": "remove_files", "file": "/kernel/drv/amd64/usbprn" },
         { "t": "remove_files", "file": "/kernel/drv/amd64/xhci" },
 
+        { "t": "remove_files", "file": "/kernel/drv/amd64/intel_nhm" },
+        { "t": "remove_files", "file": "/kernel/drv/amd64/intel_nb5000" },
+        { "t": "remove_files", "file": "/kernel/drv/amd64/mc-amd" },
+
         { "t": "remove_files", "file": "/kernel/drv/amd64/acpi_toshiba" },
         { "t": "remove_files", "file": "/kernel/drv/amd64/intel_nhmex" },
         { "t": "remove_files", "file": "/kernel/drv/intel_nhmex.conf" },


### PR DESCRIPTION
I know the long term approach is probably to split up `system/kernel`, but this Fixes #49 