### PR TITLE
Update recovery-elide.json to include fstyp

### DIFF
--- a/image/templates/include/recovery-elide.json
+++ b/image/templates/include/recovery-elide.json
@@ -969,8 +969,6 @@
         { "t": "remove_files", "file": "/usr/lib/fs/ufs/ufsdump" },
         { "t": "remove_files", "file": "/usr/lib/fs/ufs/ufsrestore" },
         { "t": "remove_files", "file": "/usr/lib/fs/ufs/volcopy" },
-        { "t": "remove_files", "file": "/usr/lib/fs/zfs/fstyp" },
-        { "t": "remove_files", "file": "/usr/lib/fs/zfs/fstyp.so.1" },
         { "t": "remove_files", "file": "/usr/lib/gss/dh1024-0.so.1" },
         { "t": "remove_files", "file": "/usr/lib/gss/dh640-0.so.1" },
         { "t": "remove_files", "file": "/usr/lib/gss/gsscred_clean" },


### PR DESCRIPTION
Add `fstyp` back into the recovery image, see https://github.com/oxidecomputer/omicron/issues/3413 for rationale