### PR TITLE
image: add egrep,dd to; remove less from recovery image.

### DIFF
--- a/image/templates/include/recovery-elide.json
+++ b/image/templates/include/recovery-elide.json
@@ -189,7 +189,6 @@
         { "t": "remove_files", "file": "/usr/bin/dumpkeys" },
         { "t": "remove_files", "file": "/usr/bin/echo" },
         { "t": "remove_files", "file": "/usr/bin/edit" },
-        { "t": "remove_files", "file": "/usr/bin/egrep" },
         { "t": "remove_files", "file": "/usr/bin/eject" },
         { "t": "remove_files", "file": "/usr/bin/elfsign" },
         { "t": "remove_files", "file": "/usr/bin/elfwrap" },


### PR DESCRIPTION
Some SMF method scripts use `/usr/bin/egrep`, so this should be restored to the recovery image. I don't know why it did not show up in the initial anonymous dtrace data collection.

`dd` has been useful to be able to manually replace the phase 2 image when booted to a recovery shell.

`less` does not work as it needs additional libraries. The image has `cat` and `more` (and `ed`) which can be used for interactive debugging.