### PR TITLE
image: disable interim crash dump management

### DIFF
--- a/image/templates/files/compliance-dump.xml
+++ b/image/templates/files/compliance-dump.xml
@@ -4,7 +4,7 @@
 <service_bundle type='manifest' name='site-compliance-dump'>
 
 <service name='site/compliance/dump' type='service' version='1'>
-  <create_default_instance enabled='true' />
+  <create_default_instance enabled='false' />
 
   <!-- Wait for local file systems, like dumpadm does: -->
   <dependency name='local-filesystems' grouping='require_all' restart_on='none'

--- a/image/templates/files/site-compliance.xml
+++ b/image/templates/files/site-compliance.xml
@@ -7,6 +7,11 @@
     <instance name='default' enabled='true' />
   </service>
 
+  <!-- Enable pilot-based dump device and crash dump management: -->
+  <service name='site/compliance/dump' version='1' type='service'>
+    <instance name='default' enabled='true' />
+  </service>
+
   <!-- See: https://www.illumos.org/issues/14006 -->
   <service name='network/routing/route' version='1' type='service'>
     <instance name='default' enabled='false' />

--- a/image/templates/gimlet/zfs.json
+++ b/image/templates/gimlet/zfs.json
@@ -55,7 +55,7 @@
 
         { "t": "ensure_file",
             "file": "/var/svc/profile/site.xml",
-            "src": "site${mfg?-mfg}.xml",
+            "src": "site${mfg?-mfg}${compliance?-compliance}.xml",
             "owner": "root", "group": "root", "mode": "644" },
 
         { "t": "include", "with": "stress", "name": "stress" },


### PR DESCRIPTION
Dump management is to be performed by the sled agent in product images; see https://github.com/oxidecomputer/omicron/pull/3586

This change disables the `pilot`-based dump device and crash dump management service which conflicts with sled agent.  The service will be enabled explicitly in images built with the **compliance** feature, which is still used by **racktest** today.