### PR TITLE
tools: include pkg manifest in image archives

### DIFF
--- a/tools/helios-build/Cargo.toml
+++ b/tools/helios-build/Cargo.toml
@@ -2,7 +2,7 @@
 name = "helios-build"
 version = "0.1.0"
 authors = ["Oxide Computer Company"]
-edition = "2018"
+edition = "2021"
 #
 # Report a specific error in the case that the toolchain is too old for
 # let-else:


### PR DESCRIPTION
This change adds more metadata to the image archive, including:

- the full list of package FMRIs for all the packages we installed during image construction
- the package publisher configuration that was in effect during construction
- the arguments that were passed to the `helios-build experiment-image` command
- some git status (including branch, hash, and a list of any local modifications) from all project directories

This should aid in understanding how an image was built after the fact.