### PR TITLE
image: add jq(1) to the image for debugging purposes

### DIFF
--- a/image/templates/gimlet/ramdisk-01-os.json
+++ b/image/templates/gimlet/ramdisk-01-os.json
@@ -60,6 +60,7 @@
             "/web/curl",
             "/text/less",
             "/text/looker",
+            "/ooce/util/jq",
             "/system/watch",
             "/editor/vim",
             "/terminal/resize",


### PR DESCRIPTION
This should address #85 by whacking `jq` in there.