### PR TITLE
image: disabled compliance/dump should not block dumpadm

### DIFF
--- a/image/templates/files/compliance-dump.xml
+++ b/image/templates/files/compliance-dump.xml
@@ -14,7 +14,7 @@
 
   <!-- Hold dumpadm back until we've had a chance to look around: -->
   <dependent name='compliance-dump-dumpadm' restart_on='none'
-    grouping='require_all'>
+    grouping='optional_all'>
     <service_fmri value='svc:/system/dumpadm'/>
   </dependent>
 


### PR DESCRIPTION
Unfortunately due to inadequate testing on my part, #102 is not a complete fix.  I missed the fact that the service had made `svc:/system/dumpadm` a dependent (which it must do, in order to be able to run first when enabled) and that it used the **require_all** grouping.  As per **smf(7)**:

```
       require_all
                       Satisfied when all cited services are running (online or
                       degraded), or when all indicated files are present.
```

This is not quite what we want; rather, if `/site/compliance/dump` is _not_ enabled, we wish `dumpadm` to proceed without waiting; i.e., we want **optional_all**:

```
       optional_all
                       Satisfied if the cited services are running (online or
                       degraded) or do not run without administrative action
                       (disabled, maintenance, not present, or offline waiting
                       for dependencies which do not start without
                       administrative action).
```