### PR TITLE
image: include xcvradm

### DIFF
--- a/config/projects.toml
+++ b/config/projects.toml
@@ -64,3 +64,9 @@ github = "oxidecomputer/compliance-pilot"
 use_ssh = true
 cargo_build = true
 auto_update = true
+
+[project.transceiver-control]
+github = "oxidecomputer/transceiver-control"
+use_ssh = true
+cargo_build = true
+auto_update = true

--- a/image/templates/gimlet/zfs-compliance.json
+++ b/image/templates/gimlet/zfs-compliance.json
@@ -81,7 +81,7 @@
             "owner": "root", "group": "bin", "mode": "0644" },
         { "t": "ensure_file",
             "file": "/usr/bin/xcvradm",
-            "extsrc": "xcvradm",
+            "extsrc": "transceiver-control/target/release/xcvradm",
             "owner": "root", "group": "bin", "mode": "0755" },
         { "t": "ensure_file",
             "file": "/usr/bin/faux-mgs",

--- a/image/templates/gimlet/zfs.json
+++ b/image/templates/gimlet/zfs.json
@@ -82,6 +82,11 @@
             "owner": "root", "group": "bin", "mode": "0755" },
         { "t": "include", "without": "no-pilot", "name": "compliance-common" },
 
+        { "t": "ensure_file",
+            "file": "/usr/bin/xcvradm",
+            "extsrc": "transceiver-control/target/release/xcvradm",
+            "owner": "root", "group": "bin", "mode": "0755" },
+
         { "t": "include", "with": "genproto",
             "name": "genproto", "file": "${genproto}" },
 


### PR DESCRIPTION
This has proven useful during customer installation troubleshooting, and so far has been manually copied into the rack.
Starting fairly soon, some customers will be less open to arbitrary binaries being injected from technician's laptops so this includes the xcvradm binary in the main gimlet image (it was already part of the compliance image, but came from the compliance dock in that case).

Booted an image built with these changes on a bench gimlet and confirmed the binary was present:

```
# which xcvradm
/usr/bin/xcvradm

# xcvradm
Administer optical network transceiver modules

Usage: xcvradm [OPTIONS] --interface <INTERFACE> <COMMAND>

Commands:
  status               Return the status of the addressed modules, such as prese
...
```
