### PR TITLE
image: customise logadm frequency and configuration

### DIFF
--- a/image/templates/files/crontab.root
+++ b/image/templates/files/crontab.root
@@ -1,0 +1,1 @@
+*/5 * * * /usr/sbin/logadm

--- a/image/templates/files/logadm.conf
+++ b/image/templates/files/logadm.conf
@@ -1,0 +1,58 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+# Copyright (c) 2001, 2010, Oracle and/or its affiliates. All rights reserved.
+#
+# logadm.conf
+#
+# Default settings for system log file management.
+# The -w option to logadm(8) is the preferred way to write to this file,
+# but if you do edit it by hand, use "logadm -V" to check it for errors.
+#
+# The format of lines in this file is:
+#       <logname> <options>
+# For each logname listed here, the default options to logadm
+# are given.  Options given on the logadm command line override
+# the defaults contained in this file.
+#
+# logadm typically runs early every morning via an entry in
+# root's crontab (see crontab(1)).
+#
+/var/log/syslog -C 8 -p 1d -a 'kill -HUP `cat /var/run/syslog.pid`'
+/var/adm/messages -C 4 -p 1d -a 'kill -HUP `cat /var/run/syslog.pid`'
+/var/cron/log -c -s 512k -t /var/cron/olog
+/var/lp/logs/lpsched -C 2 -N -t '$file.$N'
+/var/fm/fmd/errlog -N -s 2m -M '/usr/sbin/fmadm -q rotate errlog && mv /var/fm/fmd/errlog.0- $nfile'
+/var/fm/fmd/fltlog -N -A 6m -s 10m -M '/usr/sbin/fmadm -q rotate fltlog && mv /var/fm/fmd/fltlog.0- $nfile'
+#
+# Rotate the SMF logs if they exceed 100M and at least once a day.
+smf_logs_size /var/svc/log/*.log -C 8 -s 100m -c
+smf_logs_daily /var/svc/log/*.log -C 8 -p 4h -c
+#
+# The entry below is used by turnacct(8)
+#
+/var/adm/pacct -C 0 -N -a '/usr/lib/acct/accton pacct' -g adm -m 664 -o adm -p never
+#
+# The entry below manages the Dynamic Resource Pools daemon (poold(8)) logfile.
+#
+/var/log/pool/poold -N -s 512k -a 'pkill -HUP poold; true'
+/var/fm/fmd/infolog -N -A 2y -S 50m -s 10m -M '/usr/sbin/fmadm -q rotate infolog && mv /var/fm/fmd/infolog.0- $nfile'
+/var/fm/fmd/infolog_hival -N -A 2y -S 50m -s 10m -M '/usr/sbin/fmadm -q rotate infolog_hival && mv /var/fm/fmd/infolog_hival.0- $nfile'
+

--- a/image/templates/gimlet/zfs.json
+++ b/image/templates/gimlet/zfs.json
@@ -34,6 +34,14 @@
             "src": "default_init",
             "owner": "root", "group": "root", "mode": "644" },
 
+        { "t": "ensure_file", "file": "/etc/logadm.conf",
+            "src": "logadm.conf",
+            "owner": "root", "group": "sys", "mode": "644" },
+
+        { "t": "ensure_file", "file": "/var/spool/cron/crontabs/root",
+            "src": "crontab.root",
+            "owner": "root", "group": "sys", "mode": "600" },
+
         { "t": "ensure_file", "file": "/etc/ssh/sshd_config",
             "src": "sshd_config",
             "owner": "root", "group": "root", "mode": "644" },


### PR DESCRIPTION
This goes alongside https://github.com/oxidecomputer/omicron/pull/3713 which accumulates logs from zones into a dedicated, compressed, encrypted dataset in the GZ.

The default `logadm.conf` is adjusted to rotate SMF logs every time they exceed 100MiB or every four hours, and the rotated logs are swept into the GZ by sled-agent.