### PR TITLE
image: elide unused chrony service

### DIFF
--- a/image/templates/include/smf-reduce.json
+++ b/image/templates/include/smf-reduce.json
@@ -45,6 +45,8 @@
         { "t": "remove_files",
              "file": "/lib/svc/manifest/system/zones.xml" },
         { "t": "remove_files",
-             "file": "/lib/svc/manifest/system/intrd.xml" }
+             "file": "/lib/svc/manifest/system/intrd.xml" },
+        { "t": "remove_files",
+             "file": "/lib/svc/manifest/network/chrony.xml" }
     ]
 }


### PR DESCRIPTION
On a sled, chrony is started by a custom oxide/ntp service. The service that ships with the chrony package is unused and left disabled; remove it to avoid any potential confusion.