### PR TITLE
stlouis#461 platform-specific services should be enabled by platform …

### DIFF
--- a/image/templates/include/common.json
+++ b/image/templates/include/common.json
@@ -7,7 +7,7 @@
             "target": "inetd_generic.xml",
             "owner": "root", "group": "root" },
         { "t": "ensure_symlink", "link": "/etc/svc/profile/platform.xml",
-            "target": "platform_none.xml",
+	    "target": "platform_oxide.xml",
             "owner": "root", "group": "root" },
 
         { "t": "ensure_symlink", "link": "/etc/svc/profile/name_service.xml",


### PR DESCRIPTION
This change is required to be integrated in lockstep with https://code.oxide.computer/c/illumos-gate/+/292, and both together will constitute a flag day for anyone building for Gimlet.  Without this change, the constructed image won't have the ipcc and t6init services enabled.  Note that the unticketed change in oxidecomputer/image-builder 2af2ade0a4e2d5544502abcaa7553547a73b9133 doesn't get round this: while we could in principle apply both `platform_none` and `platform_oxide`, the former contains nothing anyway, and we'd still need `platform_oxide` symlinked in the image.  The non-Gimlet consumer in helios-engvm (a site profile that disables the unwanted services on PCs) is simply redundant and can be removed at leisure once this is integrated; there should be no associated flag day for i86pc consumers.