### PR TITLE
image: add column(1) to the image for debugging

### DIFF
--- a/image/templates/gimlet/ramdisk-01-os.json
+++ b/image/templates/gimlet/ramdisk-01-os.json
@@ -54,10 +54,11 @@
             "/developer/linker",
             "/diagnostic/diskinfo",
             "/diagnostic/pci",
-            "diagnostic/cpu-counters",
+            "/diagnostic/cpu-counters",
             "/system/data/hardware-registry",
             "/system/extended-system-utilities",
             "/web/curl",
+            "/text/column",
             "/text/less",
             "/text/looker",
             "/ooce/util/jq",
@@ -82,7 +83,7 @@
             "/library/expat",
             "/system/library/pcap",
 
-            "network/dns/bind",
+            "/network/dns/bind",
             "/network/openssh-server"
         ] },
 


### PR DESCRIPTION
I have [imported and packaged](https://github.com/oxidecomputer/garbage-compactor/commit/730e9d96cba800a5a58650b19fad7cee4a64f286) the [**column(1)**](https://smartos.org/man/1/column) program that was shipped in SmartOS, and which is good for massaging the output from some other program that has unaligned table-like output.  It is relatively modest:

```
$ ls -lh /usr/bin/column
-rwxr-xr-x   1 root     bin        23.9K Sep 25 16:54 /usr/bin/column
```

To ease interactive debugging, I think we should ship this in the ramdisk like we do with some other formatting programs like `jq` and `looker`.