### PR TITLE
tools: skip unneeded projects in CI

### DIFF
--- a/config/projects.toml
+++ b/config/projects.toml
@@ -1,13 +1,17 @@
 [project.illumos]
-github = "illumos/illumos-gate"
+github = "oxidecomputer/illumos-gate"
+rev = "stlouis"
+unless_env = "BUILD_OS"
 
 [project.omnios-build]
 github = "oxidecomputer/helios-omnios-build"
+unless_env = "BUILD_OS"
 use_ssh = true
 site_sh = true
 
 [project.omnios-extra]
 github = "oxidecomputer/helios-omnios-extra"
+unless_env = "BUILD_OS"
 use_ssh = true
 site_sh = true
 


### PR DESCRIPTION
There are a few repositories that `helios-build setup` checks out that are not required in that environment.
In the spirit of doing less work in CI, it would be good to skip those.