### PR TITLE
image: add opteadm/ddmadm to gimlet PATH

### DIFF
--- a/image/templates/files/bashrc
+++ b/image/templates/files/bashrc
@@ -40,15 +40,15 @@ xterm*|rxvt*|screen*|sun-color)
 esac
 
 pathdirs=(
-        "$HOME/bin"
-        '/opt/local/sbin'
-        '/opt/local/bin'
-        '/opt/ooce/sbin'
-        '/opt/ooce/bin'
-        '/usr/sbin'
-        '/usr/bin'
-        '/bin'
-        '/sbin'
+	"$HOME/bin"
+	'/opt/ooce/sbin'
+	'/opt/ooce/bin'
+	'/opt/oxide/opte/bin'
+	'/opt/oxide/mg-ddm'
+	'/usr/sbin'
+	'/usr/bin'
+	'/bin'
+	'/sbin'
 )
 export PATH=$(IFS=':'; printf '%s' "${pathdirs[*]}")
 


### PR DESCRIPTION
There was an attempt to do this in the omicron OS image builder, by adding a .profile in the overlay root but that file is not processed when `.bash_profile` is present.
Eventually perhaps sled agent should take control of root's environment, replacing whatever is in the image, but in the meantime it would be useful for `opteadm` and `ddmadm` to be in the GZ root's path.

This template file is only used by the gimlet image as far as I can see.