### PR TITLE
Clarify that helios is the Oxide rack OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Oxide Helios
 
-Helios is a distribution of illumos intended to power the Oxide Rack.  The full
+Helios is a distribution of illumos powering the Oxide Rack.  The full
 distribution is built from several consolidations of software, driven from
 tools and documentation in this top-level repository.
 


### PR DESCRIPTION
Change leading sentence of the readme, changing it from a stated intention to the actual fact that helios powers the Oxide rack.

Discussed over chat channel with @steveklabnik.