### PR TITLE
image: bump gimlet ramdisk zfs size

### DIFF
--- a/image/templates/gimlet/zfs.json
+++ b/image/templates/gimlet/zfs.json
@@ -4,7 +4,7 @@
         "bename": "ramdisk",
         "ashift": 9,
         "uefi": false,
-        "size": 800,
+        "size": 1000,
         "label": false,
         "no_features": false,
         "compression": "gzip-9",


### PR DESCRIPTION
Due to

- https://github.com/oxidecomputer/omicron/runs/21919005159