### PR TITLE
config: enable auto-update for phbl project

### DIFF
--- a/config/projects.toml
+++ b/config/projects.toml
@@ -29,6 +29,7 @@ cargo_build = true
 [project.phbl]
 github = "oxidecomputer/phbl"
 use_ssh = false
+auto_update = true
 
 [project.image-builder]
 github = "illumos/image-builder"


### PR DESCRIPTION
At present `phbl` is not pinned but is never updated after the first helios
checkout/gmake setup. Let's always fetch the latest version.
