### PR TITLE
image: Update token values to new enum variants now that we know

### DIFF
--- a/image/amd/milan-gimlet-b.efs.json5
+++ b/image/amd/milan-gimlet-b.efs.json5
@@ -4219,7 +4219,7 @@
 										},
 										{
 											Byte: {
-												MemTrainingHdtControl: "StageCompletionMessages1"
+												MemTrainingHdtControl: "AssertionMessages"
 											}
 										},
 										{
@@ -4314,7 +4314,7 @@
 										},
 										{
 											Byte: {
-												FchConsoleOutMode: 0x00
+												FchConsoleOutMode: "Disabled"
 											}
 										},
 										{


### PR DESCRIPTION
With new processor generations, sometimes AMD describes meanings of some of the old tokens that previously had only empirical meaning. Previously, we didn't actually know what exactly `ConsoleOutMode`'s and `MemTrainingHdtControl`'s values meant so we used placeholders.

Now that we know the meanings for Genoa, let's also use them for Milan.

See also https://github.com/oxidecomputer/amd-apcb/commit/5a35018e09eb452b2d8baa50555c305def21bdb6#diff-88041fcad5b235e8943f0bdaab24e9d658e74dd8c91978e6bf60ed0eba0e566fR8564 and https://github.com/oxidecomputer/amd-apcb/commit/5a35018e09eb452b2d8baa50555c305def21bdb6#diff-88041fcad5b235e8943f0bdaab24e9d658e74dd8c91978e6bf60ed0eba0e566fR7232 for the corresponding changes in amd-apcb.