### PR TITLE
image: allow extra packages to be installed via -F

### DIFF
--- a/image/templates/gimlet/ramdisk-01-os.json
+++ b/image/templates/gimlet/ramdisk-01-os.json
@@ -113,6 +113,11 @@
         { "t": "pkg_install", "with": "stress", "pkgs": [
             "/ooce/util/stress-ng",
             "/system/test/fio"
+        ] },
+
+        { "t": "pkg_install", "with": "nfs", "pkgs": [
+            "/system/file-system/autofs",
+            "/system/file-system/nfs"
         ] }
     ]
 }

--- a/image/templates/gimlet/ramdisk-01-os.json
+++ b/image/templates/gimlet/ramdisk-01-os.json
@@ -83,7 +83,9 @@
             "/system/library/pcap",
 
             "/network/dns/bind",
-            "/network/openssh-server"
+            "/network/openssh-server",
+
+            "${@extra_packages}"
         ] },
 
         { "t": "pkg_install", "without": "recovery", "pkgs": [

--- a/image/templates/include/smf-reduce.json
+++ b/image/templates/include/smf-reduce.json
@@ -2,9 +2,11 @@
     "steps": [
         { "t": "remove_files", "dir": "/lib/svc/manifest/network/ipsec" },
         { "t": "remove_files", "dir": "/lib/svc/manifest/network/ldap" },
-        { "t": "remove_files", "dir": "/lib/svc/manifest/network/rpc" },
+        { "t": "remove_files", "without": "nfs",
+            "dir": "/lib/svc/manifest/network/rpc" },
         { "t": "remove_files", "dir": "/lib/svc/manifest/network/security" },
-        { "t": "remove_files", "dir": "/lib/svc/manifest/network/shares" },
+        { "t": "remove_files", "without": "nfs",
+            "dir": "/lib/svc/manifest/network/shares" },
         { "t": "remove_files", "dir": "/lib/svc/manifest/network/smb" },
         { "t": "remove_files",
              "file": "/lib/svc/manifest/application/management/net-snmp.xml" },
@@ -42,7 +44,7 @@
              "file": "/lib/svc/manifest/system/device/mpxio-upgrade.xml" },
         { "t": "remove_files",
              "file": "/lib/svc/manifest/system/hostid.xml" },
-        { "t": "remove_files",
+        { "t": "remove_files", "without": "nfs",
              "file": "/lib/svc/manifest/system/idmap.xml" },
         { "t": "remove_files",
              "file": "/lib/svc/manifest/system/pkgserv.xml" },
@@ -50,7 +52,7 @@
              "file": "/lib/svc/manifest/system/zones.xml" },
         { "t": "remove_files",
              "file": "/lib/svc/manifest/system/intrd.xml" },
-        { "t": "remove_files",
+        { "t": "remove_files", "without": "ntp",
              "file": "/lib/svc/manifest/network/chrony.xml" }
     ]
 }


### PR DESCRIPTION
This small change builds on [a new **image-builder**](https://github.com/illumos/image-builder/commit/de9447e51117ba115ce44c484d2c2c82ec47873a) facility: the expansion of multi-valued features into lists like those used by the `pkg_install` and `pkg_uninstall` steps.

In particular, this allows an engineer to throw a handful of extra packages into an ad hoc image without needing to edit any templates; e.g.,

```
./helios-build experiment-image \
    -p helios-dev=https://pkg.oxide.computer/helios/2/dev/ \
    -P "$proto" \
    -B \
    -F optever=0.29 \
    -F nfs \
    -F ntp \
    -F extra_packages+=/ooce/editor/neovim \
    -F extra_packages+=/terminal/tmux \
    -N "$name" \
    -o "$OSDIR/$image"
```

Note that the two `-F extra_packages+=...` lines add two packages to the `extra_packages` feature, which then gets expanded into two entries in the array at the position where the `${@extra_packages}` macro appears.

NB: This PR is stacked on top of #155.

### Testing Notes

I have tested this both with the above command, and also with the much simpler invocation:

```
./helios-build experiment-image -p helios-dev=https://pkg.oxide.computer/helios/2/dev/ 
```

I confirmed in both cases that the packages showed up only when they were expected to show up.