### PR TITLE
Add optional 'netperf' package set.

### DIFF
--- a/image/templates/gimlet/ramdisk-01-os.json
+++ b/image/templates/gimlet/ramdisk-01-os.json
@@ -109,6 +109,12 @@
             "/driver/developer/amd/zen"
         ] },
 
+        { "t": "pkg_install", "with": "netperf", "pkgs": [
+            "/network/test/iperf",
+            "/system/library/demangle",
+            "/ooce/developer/flamegraph"
+        ] },
+
         { "t": "pkg_install", "with": "compliance", "pkgs": [
             "/driver/developer/amd/zen",
             "/developer/debug/humility"


### PR DESCRIPTION
We're currently using these packages as part of oxidecomputer/opte#486, and it was suggested that this option might be useful upstream in a similar vein as 'stress'.