### PR TITLE
Tune zfs parameters for improved IO performance

### DIFF
--- a/image/templates/files/gimlet-system-zfs:dbuf
+++ b/image/templates/files/gimlet-system-zfs:dbuf
@@ -21,11 +21,13 @@ set zfs:dbuf_metadata_cache_max_bytes = 0x40000000
 *
 set zfs:zfs_vdev_aggregation_limit = 0
 
-* These taskqueues will allocate threads equal to 75% of the number of CPU
-* threads on the system. On the gimlet, that means that it allocates 96 threads.
-* These queues are per-zpool, so actually that means it allocates 960 threads by
-* default. This is a bit excessive. These parameters bring it down to allocate
-* 5% per pool instead, significantly reducing mutex contention between the
-* worker threads.
+*
+* These task queues will allocate threads equal to 75% of the number of CPU
+* threads on the system.  On the Gimlet, that means that it allocates 96
+* threads.  These queues are per-zpool, so actually that means it allocates 960
+* threads by default.  This is a bit excessive.  These parameters bring it down
+* to allocate 5% per pool instead, significantly reducing mutex contention
+* between the worker threads.
+*
 set zfs:zfs_sync_taskq_batch_pct = 5
 set zfs:zio_taskq_batch_pct = 5

--- a/image/templates/files/gimlet-system-zfs:dbuf
+++ b/image/templates/files/gimlet-system-zfs:dbuf
@@ -10,13 +10,15 @@
 set zfs:dbuf_cache_max_bytes = 0x40000000
 set zfs:dbuf_metadata_cache_max_bytes = 0x40000000
 
-* by default, zfs tries to internally aggregate multiple IO operations, so it
-* can dispatch them as a single operation to the disk. This logic comes from the
-* era of spinning drives, where putting in the work to issue fewer, larger
-* commands would increase throughput. For SSDs, and especially the gimlet SSDs,
-* it instead generates extra work within ZFS that reduces throughput.
+*
+* By default, ZFS tries to internally aggregate multiple I/O operations, so it
+* can dispatch them as a single operation to the disk.  This logic comes from
+* the era of spinning drives, where putting in the work to issue fewer, larger
+* commands would increase throughput.  For SSDs, and especially the Gimlet
+* SSDs, it instead generates extra work within ZFS that reduces throughput.
 *
 * We set the limit to 0 disable aggregation entirely.
+*
 set zfs:zfs_vdev_aggregation_limit = 0
 
 * These taskqueues will allocate threads equal to 75% of the number of CPU

--- a/image/templates/files/gimlet-system-zfs:dbuf
+++ b/image/templates/files/gimlet-system-zfs:dbuf
@@ -10,3 +10,20 @@
 set zfs:dbuf_cache_max_bytes = 0x40000000
 set zfs:dbuf_metadata_cache_max_bytes = 0x40000000
 
+* by default, zfs tries to internally aggregate multiple IO operations, so it
+* can dispatch them as a single operation to the disk. This logic comes from the
+* era of spinning drives, where putting in the work to issue fewer, larger
+* commands would increase throughput. For SSDs, and especially the gimlet SSDs,
+* it instead generates extra work within ZFS that reduces throughput.
+*
+* We set the limit to 0 disable aggregation entirely.
+set zfs:zfs_vdev_aggregation_limit = 0
+
+* These taskqueues will allocate threads equal to 75% of the number of CPU
+* threads on the system. On the gimlet, that means that it allocates 96 threads.
+* These queues are per-zpool, so actually that means it allocates 960 threads by
+* default. This is a bit excessive. These parameters bring it down to allocate
+* 5% per pool instead, significantly reducing mutex contention between the
+* worker threads.
+set zfs:zfs_sync_taskq_batch_pct = 5
+set zfs:zio_taskq_batch_pct = 5


### PR DESCRIPTION
We tune three zfs parameters:

- zfs:zfs_vdev_aggregation_limit - disable
- zfs:zfs_sync_taskq_batch_pct   - reduce to 5%
- zfs:zio_taskq_batch_pct        - reduce to 5%

Like previous zfs tuning, these are about bringing zfs parameters in line with the reality of a modern system like the gimlet, away from defaults that were good on a system with few CPU threads and high-latency spinning disks.

For crucible with a 4k rand write workload, we see an 18% reduction in CPU usage and a 15% increase in throughput. We see no significant change to our 4k rand read or our 4k sequential workloads.

The crucible 4k rand write workload is the most pathological workload we have for zfs on the rack today. Therefore, I do not expect this change to have a negative impact on cockroach/clickhouse (if anything, it might help them out). I have not verified this experimentally.

I built a helios image with this change and booted it on a bench gimlet. I confirmed that the parameters have been changed as we expect:

```
EVT22200004 # mdb -ke 'zfs_vdev_aggregation_limit/D'
zfs_vdev_aggregation_limit:
zfs_vdev_aggregation_limit:     0
EVT22200004 # mdb -ke 'zfs_sync_taskq_batch_pct/D'
zfs_sync_taskq_batch_pct:
zfs_sync_taskq_batch_pct:       5
EVT22200004 # mdb -ke 'zio_taskq_batch_pct/D'
zio_taskq_batch_pct:
zio_taskq_batch_pct:            5
```