### PR TITLE
recovery elides too greedily and too deep; awakens eventfd

### DIFF
--- a/image/templates/include/recovery-elide.json
+++ b/image/templates/include/recovery-elide.json
@@ -519,7 +519,6 @@
         { "t": "remove_files", "file": "/usr/kernel/drv/amd64/pts" },
         { "t": "remove_files", "file": "/usr/kernel/drv/amd64/vmm" },
         { "t": "remove_files", "file": "/usr/kernel/drv/amd64/zcons" },
-        { "t": "remove_files", "file": "/usr/kernel/drv/eventfd.conf" },
         { "t": "remove_files", "file": "/usr/kernel/drv/fssnap.conf" },
         { "t": "remove_files", "file": "/usr/kernel/drv/ksyms.conf" },
         { "t": "remove_files", "file": "/usr/kernel/drv/logindmux.conf" },


### PR DESCRIPTION
tokio 1.39 and above use **eventfd(7)** instead of the more traditional self-pipe mechanism for injecting wake-ups into the event loop.  We are, regrettably, not including the **eventfd.conf** configuration file for the **eventfd** kernel module in the recovery image.  This causes the **installinator** to fail to start:

```
BRM42220062 # svcs -a | grep oxide
online          0:00:34 svc:/oxide/installinator:default
BRM42220062 # tail -F $(svcs -L installinator)
[ Dec 28 00:00:02 Enabled. ]
[ Dec 28 00:00:34 Executing start method ("ctrun -l child -o noorphan,regent /opt/oxide/installinator/installinator install --bootstrap-sled --from-ipcc --install-on-gimlet --stay-alive &"). ]
[ Dec 28 00:00:34 Method "start" exited with status 0. ]
thread 'main' panicked at installinator/src/main.rs:15:7:
Failed building the Runtime: Os { code: 2, kind: NotFound, message: "No such file or directory" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Interestingly this didn't cause the service to fail, or even to retry... It seems like the service uses the "transient" duration, which may be another (separate) bug.