### PR TITLE
tools: accept "help" top-level command, show usage on errors

### DIFF
--- a/tools/helios-build/src/main.rs
+++ b/tools/helios-build/src/main.rs
@@ -65,8 +65,9 @@ fn baseopts() -> getopts::Options {
 
     /*
      * We should always have a --help flag everywhere.
+     * Accept -h as well as --help for good measure.
      */
-    opts.optflag("", "help", "usage information");
+    opts.optflag("h", "help", "usage information");
 
     opts
 }
@@ -2441,7 +2442,7 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
-    if res.free.is_empty() {
+    if res.free.is_empty() || res.free[0] == "help" {
         usage();
         bail!("choose a command");
     }


### PR DESCRIPTION
`helios-build` has supported `--help` since forever, but as @rmustacc found in #12 and i rediscovered yesterday, not `-h` nor a top-level "help" command. seems like it'd be good to accept all of `--help`, `-h`, `helios-build help`, or the bare `./helios-build` to get usage information, so this change does that.

also, because it's in `baseopts`, this means `-h` is now a flag for all the subcommands too.