### PR TITLE
image: apply generic and platform SMF profiles

### DIFF
--- a/image/templates/gimlet/zfs-recovery.json
+++ b/image/templates/gimlet/zfs-recovery.json
@@ -65,6 +65,12 @@
             "name": "genproto", "file": "${genproto}" },
 
         { "t": "include", "name": "smf-reduce" },
-        { "t": "seed_smf", "apply_site": true, "skip_seed": true }
+        { "t": "seed_smf", "skip_seed": true,
+            "apply_profiles": [
+                "generic",
+                "platform",
+                "site"
+            ]
+        }
     ]
 }

--- a/image/templates/gimlet/zfs.json
+++ b/image/templates/gimlet/zfs.json
@@ -81,6 +81,12 @@
             "name": "genproto", "file": "${genproto}" },
 
         { "t": "include", "name": "smf-reduce" },
-        { "t": "seed_smf", "apply_site": true, "skip_seed": true }
+        { "t": "seed_smf", "skip_seed": true,
+            "apply_profiles": [
+                "generic",
+                "platform",
+                "site"
+            ]
+        }
     ]
 }


### PR DESCRIPTION
In manufacturing, we use a custom Helios image to boot the Gimlet.  This is achieved with the **mfg** feature, which changes the image behaviour in a few critical places.

One of those things is that we ship a custom **site** SMF profile.  This profile disables the **/system/t6init** service so that we can poke at the T6 ourselves prior to it coming up.

I recently built a new **mfg** image and the T6 service started again automatically.  This is because, while we apply the **site** profile during image construction we do not apply the **platform** profile.  Applying a profile generates a record in the SMF repository with the hash and path of the profile that was imported, so the image contained the following record of profiles:

    $ SVCCFG_REPOSITORY=/tmp/sigh.db svccfg -s /smf/manifest listprop | grep profile | column -t
    var_svc_profile_site_xml               framework
    var_svc_profile_site_xml/manifestfile  astring    /var/svc/profile/site.xml
    var_svc_profile_site_xml/md5sum        opaque     a43e81647ee71df98654ea6addba21d56669ad34c8c0af8edf3f9fe0915f59cb

At boot, the **early-manifest-import** service looks at what's been applied before, sees that we have apparently _not_ applied the **platform** profile, and applies it.  It does _not_ redo the **site** profile, because that record (created during image building, earlier) still matches the **site.xml** file.

The thing that changed in the background between the last **mfg** image and this new one is that oxidecomputer/stlouis#461 correctly changes the **/system/t6init** service to be disabled by default (because it only makes sense on **oxide**, not on **i86pc**) and then _enables_ it in the **platform_oxide.xml** profile file.  By applying the three main profiles (**generic**, **platform**, and **site**) in the correct sequence, we prevent the need for SMF to do it again on first boot, and get the behaviour we were originally looking for.

This ought to have no impact on any image that already worked correctly, as we're just applying the profiles that would otherwise have been applied anyway.