### PR TITLE
image: include /driver/cpu/amd/zen in cpio for dramtest

### DIFF
--- a/image/mkcpio.sh
+++ b/image/mkcpio.sh
@@ -43,6 +43,8 @@ kernel/crypto/amd64/sha2
 kernel/crypto/amd64/skein
 kernel/crypto/amd64/swrand
 kernel/dacf/amd64/net_dacf
+kernel/drv/amd64/amdzen
+kernel/drv/amd64/amdzen_stub
 kernel/drv/amd64/bl
 kernel/drv/amd64/blkdev
 kernel/drv/amd64/clone
@@ -87,7 +89,9 @@ kernel/drv/amd64/t4nex
 kernel/drv/amd64/ucode
 kernel/drv/amd64/ufm
 kernel/drv/amd64/vnic
+kernel/drv/amd64/zen_umc
 kernel/drv/amd64/zfs
+kernel/drv/amdzen.conf
 kernel/drv/bl.conf
 kernel/drv/bridge.conf
 kernel/drv/clone.conf
@@ -206,6 +210,7 @@ kernel/misc/amd64/sha2
 kernel/misc/amd64/skein
 kernel/misc/amd64/strplumb
 kernel/misc/amd64/tlimod
+kernel/misc/amd64/zen_data
 kernel/sched/amd64/SDC
 kernel/sched/amd64/TS
 kernel/sched/amd64/TS_DPTBL


### PR DESCRIPTION
As part of building a new image for the DRAM testing station in manufacturing, I have rebased the [dramtest](https://github.com/oxidecomputer/illumos-gate/tree/dramtest) branch of illumos on top of the latest **stlouis** bits.  The code in the branch essentially blocks forever in the **boot_image** module, loads the **zen_umc** module, and prints out information about the DIMMs in the machine over and over.  The manufacturing software knows how to interpret this data (by watching the console) to produce a report.

It would appear that the last time I built the image for this purpose, I was (somehow) including the **zen_umc** module and other parts of the **/driver/cpu/amd/zen** package in the cpio archive.  It's possible that part of making the image ready for production involved trimming those files out.

The files are not strictly necessary in the regular image, but they also only increase the size of the compressed cpio archive from 8.22MB to 8.27MB.  It doesn't seem worth adding complexity to make them optional here, given the small size.