### PR TITLE
nvme-loadgen should not create a default instance

### DIFF
--- a/image/templates/files/compliance-nvme-loadgen.xml
+++ b/image/templates/files/compliance-nvme-loadgen.xml
@@ -7,8 +7,6 @@
 <service_bundle type='manifest' name='site-compliance-nvme-loadgen'>
 
 <service name='site/compliance/nvme-loadgen' type='service' version='1'>
-    <create_default_instance enabled='false' />
-
     <!-- Wait for multi-user. -->
     <dependency name="multi_user"
                 grouping="require_all"


### PR DESCRIPTION
This addresses the issue raised in #210. I tested this on c71, verified that there was no default instance, and that the non-default worked for the drives that were present in the system.