### PR TITLE
image: compliance/beacon service comes online too early

### DIFF
--- a/image/templates/files/compliance-beacon.xml
+++ b/image/templates/files/compliance-beacon.xml
@@ -15,12 +15,10 @@
         <service_fmri value='svc:/milestone/multi-user-server' />
     </dependency>
 
-    <!-- ... and make sure we have some networking up to announce on. -->
-    <dependency name='net' grouping='require_any' restart_on='none'
+    <!-- ... and make sure we run after the T6 has been configured. -->
+    <dependency name='t6init' grouping='require_all' restart_on='none'
         type='service'>
-        <service_fmri value='svc:/oxide/net-setup:igb' />
-        <service_fmri value='svc:/oxide/net-setup:e1000g' />
-        <service_fmri value='svc:/oxide/net-setup:cxgbe' />
+        <service_fmri value='svc:/system/t6init' />
     </dependency>
 
     <!-- ... and after our postboot script. -->


### PR DESCRIPTION
Fixes #214 

I'm not sure if there's anything better to be done here in terms of waiting for `cxgbe` if it's going to appear, and `igb` otherwise. Despite its name, `compliance/beacon` is used in production images for announce, and in the last dogfood update the service started too early - before the cxgbe NICs appeared.