### PR TITLE
Don't gate beacon service on T6 if other suitable NICs exist

### DIFF
--- a/image/templates/files/compliance-postboot.xml
+++ b/image/templates/files/compliance-postboot.xml
@@ -15,13 +15,6 @@
         <service_fmri value='svc:/milestone/multi-user-server' />
     </dependency>
 
-    <!-- ... and make sure we run after the T6 has been configured and the
-         cxgbe links have been assigned link-local v6 addresses. -->
-    <dependency name='net-setup-cxgbe' grouping='require_all' restart_on='none'
-        type='service'>
-        <service_fmri value='svc:/oxide/net-setup:cxgbe' />
-    </dependency>
-
     <!-- Compliance postboot is just a milestone service. -->
     <exec_method type='method' name='start' exec=':true' timeout_seconds='30' />
     <exec_method type='method' name='stop' exec=':true' timeout_seconds='30' />


### PR DESCRIPTION
#203 updated `site/compliance/beacon` to use a `require_any` for the `igb/e1000g/cxgbe` instance of `oxide/net-setup`. That along with oxidecomputer/pilot#70 was intended to allow us to start announcing on a k.2 attached nic if present even if the T6 failed to come up (as it has been prone to on Cosmo).

Unfortunately that wasn't quite enough as `site/compliance/beacon` depends on `site/postboot` and with `-F compliance`,  the `site/postboot` service depended on `oxide/net-setup:cxgbe` (note that's `site/postboot` as described by `compliance-postboot.xml` and not `site-postboot.xml`).

```
online          0:00:03 svc:/oxide/net-setup:igb
offline         0:00:02 svc:/oxide/net-setup:cxgbe
offline         0:00:02 svc:/site/postboot:default
offline         0:00:02 svc:/site/compliance/beacon:default
offline*        0:00:05 svc:/site/compliance/tofino:default
maintenance     0:00:09 svc:/system/t6init:default
BRM22250003 # svcs -xv
svc:/system/t6init:default (Verify, program and initialise the T6)
 State: maintenance since Sun Dec 28 00:00:09 1986
Reason: Start method exited with $SMF_EXIT_ERR_FATAL.
   See: http://illumos.org/msg/SMF-8000-KS
   See: /var/svc/log/system-t6init:default.log
Impact: 3 dependent services are not running:
        svc:/oxide/net-setup:cxgbe
        svc:/site/postboot:default
        svc:/site/compliance/beacon:default

svc:/site/compliance/tofino:default (compliance tofino)
 State: offline since Sun Dec 28 00:00:05 1986
Reason: Start method is running.
   See: http://illumos.org/msg/SMF-8000-C4
   See: /var/svc/log/site-compliance-tofino:default.log
Impact: This service is not running.
```

This just updates `compliance-postboot.xml` to not explicitly depend on `oxide/net-setup:cxgbe`.

(At this point, the compliance version of postboot doesn't actually do anything but I'm leaving it as-is to not trip up things expecting it and suddenly failing if passed `-F compliance`)