### PR TITLE
image: NFS services require the inetd restarter

### DIFF
--- a/image/templates/include/smf-reduce.json
+++ b/image/templates/include/smf-reduce.json
@@ -16,7 +16,7 @@
              "file": "/lib/svc/manifest/network/dns/install.xml" },
         { "t": "remove_files",
              "file": "/lib/svc/manifest/network/inetd-upgrade.xml" },
-        { "t": "remove_files",
+        { "t": "remove_files", "without": "nfs",
              "file": "/lib/svc/manifest/network/inetd.xml" },
         { "t": "remove_files",
              "file": "/lib/svc/manifest/network/network-install.xml" },


### PR DESCRIPTION
My change in #155 missed that we have unfortunately also removed the **[inetd(8)](https://illumos.org/man/8/inetd)** [smf_restarter(7)](https://illumos.org/man/7/smf_restarter) service bundle, which is a critical component of other services.  This change puts it back for images that request NFS support.