### PR TITLE
image: add Gimlet fallback microcode to phase1

### DIFF
--- a/image/mkcpio.sh
+++ b/image/mkcpio.sh
@@ -240,6 +240,7 @@ platform/oxide/kernel/misc/amd64/pci_prd
 platform/oxide/kernel/misc/amd64/pcie
 platform/oxide/kernel/sys/amd64/cpc
 platform/oxide/ucode/AuthenticAMD/A011-00
+platform/oxide/ucode/AuthenticAMD/fallback/A011-00
 platform/oxide/ucode/AuthenticAMD/B021-00
 platform/oxide/ucode/AuthenticAMD/B110-00
 platform/oxide/ucode/AuthenticAMD/equivalence-table


### PR DESCRIPTION
This will need to be merged at the same time as https://github.com/oxidecomputer/stlouis/issues/836 in order for Gimlets running the older PI 1.0.0.a to still receive a CPU microcode update on boot.