### PR TITLE
image: add psp nexus and error injection drivers to mfg & compliance images

### DIFF
--- a/image/templates/sled/ramdisk-01-os.json
+++ b/image/templates/sled/ramdisk-01-os.json
@@ -111,11 +111,15 @@
         ] },
 
         { "t": "pkg_install", "with": "mfg", "pkgs": [
-            "/driver/developer/amd/zen"
+            "/driver/developer/amd/zen",
+            "/driver/cpu/amd/psp",
+            "/driver/developer/amd/psp/einj"
         ] },
 
         { "t": "pkg_install", "with": "compliance", "pkgs": [
             "/driver/developer/amd/zen",
+            "/driver/cpu/amd/psp",
+            "/driver/developer/amd/psp/einj",
             "/developer/debug/humility"
         ] },
 


### PR DESCRIPTION
Pulls in the new packages introduced as part of https://code.oxide.computer/c/illumos-gate/+/626.