### PR TITLE
image: remove temporary ZFS Fsync tuning

### DIFF
--- a/image/templates/files/sled-system-zfs:zil
+++ b/image/templates/files/sled-system-zfs:zil
@@ -1,9 +1,0 @@
-*
-* By default the first four writes following an fsync() are afforded special
-* treatment and always written to the ZIL as synchronous transactions. On
-* files which are otherwise asynchronous this can cause out of order writes
-* should the ZIL ever be replayed, and if interspersed with a truncate
-* operation can result in data corruption. We disable this special treatment
-* for now. See https://www.illumos.org/issues/17734 for more details.
-*
-set zfs:zfs_fsync_sync_cnt = 0

--- a/image/templates/sled/ramdisk-02-trim.json
+++ b/image/templates/sled/ramdisk-02-trim.json
@@ -112,11 +112,6 @@
             "src": "sled-system-zfs:dbuf",
             "owner": "root", "group": "sys", "mode": "0644" },
 
-        { "t": "ensure_file",
-            "file": "/etc/system.d/zfs:zil",
-            "src": "sled-system-zfs:zil",
-            "owner": "root", "group": "sys", "mode": "0644" },
-
         { "t": "assemble_files",
             "dir": "/etc/system.d",
             "output": "/etc/system.d/.self-assembly" },


### PR DESCRIPTION
This has been superseded by [illumos 17734](https://www.illumos.org/issues/17734) and the tuneable no longer exists.