### PR TITLE
bump ramdisk to 1050MB

### DIFF
--- a/image/templates/sled/zfs.json
+++ b/image/templates/sled/zfs.json
@@ -4,7 +4,7 @@
         "bename": "ramdisk",
         "ashift": 9,
         "uefi": false,
-        "size": 2000,
+        "size": 1050,
         "label": false,
         "no_features": false,
         "compression": "gzip-9",


### PR DESCRIPTION
When adding a new binary to omicron, the TUF repo build failed because the ramdisk ran out of space.  This change bumps the size from 1000MB to 2000MB, enabling the TUF build to finish.  Obviously we could get by with a much smaller size increase, if there is some reason that would be preferable.