### PR TITLE
image: recreate dendrite service if it exists

### DIFF
--- a/image/templates/files/compliance-tofino.xml
+++ b/image/templates/files/compliance-tofino.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
 <!--
-    Copyright 2024 Oxide Computer Company
+    Copyright 2025 Oxide Computer Company
 -->
 
 <service_bundle type='manifest' name='postboot'>
@@ -16,7 +16,7 @@
     </dependency>
 
     <exec_method type='method' name='start'
-        exec='/usr/bin/pilot dendrite create -w' timeout_seconds='3600' />
+        exec='/usr/bin/pilot dendrite create -rw' timeout_seconds='3600' />
 
     <exec_method type='method' name='stop' exec=':true' timeout_seconds='30' />
 


### PR DESCRIPTION
Cosmos in the scrimlet position were having trouble bringing up the switch zone in a racktest image.  Looking at the log:

```
271F4FKC # cat $(svcs -L tofino)
[ Dec 28 00:00:06 Enabled. ]
[ Dec 28 00:00:09 Executing start method ("/usr/bin/pilot dendrite create -w"). ]
 * found tofino devices: ["/dev/tofino/1"]
 * creating...
 * installing...
Error: zone install for "dendrite": "exit code 1: Error: IO error for operation on /usr/share/man/whatis.tmp: No such file or directory (os error 2)\n\nCaused by:\n    No such file or directory (os error 2)"
[ Dec 28 00:00:09 Method "start" exited with status 1. ]
[ Dec 28 00:00:09 Executing start method ("/usr/bin/pilot dendrite create -w"). ]
 * found tofino devices: ["/dev/tofino/1"]
Error: zone exists already!
[ Dec 28 00:00:09 Method "start" exited with status 1. ]
[ Dec 28 00:00:09 Executing start method ("/usr/bin/pilot dendrite create -w"). ]
 * found tofino devices: ["/dev/tofino/1"]
Error: zone exists already!
[ Dec 28 00:00:09 Method "start" exited with status 1. ]
```

The initial problem is ostensibly some kind of race with the `svc:/system/update-man-index:default` service.  I assume the zone brand finds the `whatis.tmp` file during enumeration, and then it's gone by the time we decide to try and copy it into the zone.

This change doesn't fix that problem, but it does change the service to first try and tear down an existing switch zone if there is one, rather than fail.  I added the flag in this **pilot** commit: https://github.com/oxidecomputer/pilot/commit/bb7eca813d97cb829461148fd308e9f36264f787.