### PR TITLE
tools: allow for a custom ramdisk target size

### DIFF
--- a/tools/helios-build/src/main.rs
+++ b/tools/helios-build/src/main.rs
@@ -1367,6 +1367,7 @@ fn cmd_image(ca: &CommandArg) -> Result<()> {
         "PUBLISHER=URL",
     );
     opts.optopt("P", "", "include all files from extra proto area", "DIR");
+    opts.optopt("S", "", "ramdisk target size", "GIGABYTES");
 
     let group = "sled";
 
@@ -1835,7 +1836,12 @@ fn cmd_image(ca: &CommandArg) -> Result<()> {
     /*
      * Create the image and extract the checksum:
      */
-    let target_size = 4 * 1024;
+    let target_size = if let Some(gb) = res.opt_str("S") {
+        let gb: u32 = gb.parse()?;
+        gb * 1024
+    } else {
+        4 * 1024
+    };
     info!(log, "creating Oxide boot image...");
     let mut cmd = Command::new(&mkimage);
     cmd.arg("-i").arg(&raw);


### PR DESCRIPTION
As part of sorting out oxidecomputer/buildomat#72 it was helpful to be able to customise the ramdisk target size when building some images.

(Recall that the target size does not affect the image file size, it's merely an embedded parameter; the kernel expands the ZFS pool to the target size at boot, leaving more room for activities.)