### PR TITLE
nvme-loadgen: partition disk if necessary

### DIFF
--- a/image/templates/files/compliance-nvme-loadgen.sh
+++ b/image/templates/files/compliance-nvme-loadgen.sh
@@ -63,7 +63,16 @@ for nvme do
 		fatal "Unknown device \"$nvme\""
 	fi
 	dev="${nvme_dev_map[$nvme]}p0"
-	out_files+=("$devdir/$dev")
+	devfile="$devdir/$dev"
+	if [[ ! -b "$devfile" ]]; then
+		rm -f "$devfile"
+		diskdev="$devdir/${nvme_dev_map[$nvme]}"
+		fdisk -E "$diskdev"
+	fi
+	if [[ ! -e "$devfile" ]]; then
+		fatal "Device file \"$devfile\" does not exist"
+	fi
+	out_files+=("$devfile")
 done
 
 env \


### PR DESCRIPTION
`nvme-loadgen` fails if any of the target disk
devices disk is unpartitioned.  Detect this and
partition them if necessary.

Fixes #209