### PR TITLE
helios#241 Ship i2c in the non-recovery image

### DIFF
--- a/image/templates/sled/ramdisk-01-os.json
+++ b/image/templates/sled/ramdisk-01-os.json
@@ -97,7 +97,8 @@
             "/developer/object-file",
             "/system/ksensor",
             "/driver/cpu/sensor",
-            "/driver/ktest"
+            "/driver/ktest",
+            "/system/i2c"
         ] },
 
         { "t": "pkg_install", "with": "omicron1", "pkgs": [


### PR DESCRIPTION
See #241 for details.