### PR TITLE
Include driver/developer/amd/zen in all images

### DIFF
--- a/image/templates/include/recovery-elide-v3.json
+++ b/image/templates/include/recovery-elide-v3.json
@@ -478,6 +478,10 @@
         { "t": "remove_files", "file": "/usr/has/bin/vi" },
         { "t": "remove_files", "file": "/usr/has/bin/view" },
 
+        { "t": "remove_files", "file": "/kernel/drv/amd64/uhsmp" },
+        { "t": "remove_files", "file": "/kernel/drv/amd64/usmn" },
+        { "t": "remove_files", "file": "/kernel/drv/amd64/zen_udf" },
+
         { "t": "remove_files", "file": "/usr/kernel/drv/amd64/logindmux" },
         { "t": "remove_files", "file": "/usr/kernel/drv/amd64/pool" },
         { "t": "remove_files", "file": "/usr/kernel/drv/amd64/ppt" },
@@ -513,6 +517,10 @@
 
         { "t": "remove_files", "file": "/usr/kvm/README" },
 
+        { "t": "remove_files", "file": "/usr/lib/apobdump" },
+        { "t": "remove_files", "file": "/usr/lib/udf" },
+        { "t": "remove_files", "file": "/usr/lib/uhsmp" },
+        { "t": "remove_files", "file": "/usr/lib/usmn" },
         { "t": "remove_files", "file": "/usr/lib/abi/spec2map" },
         { "t": "remove_files", "file": "/usr/lib/abi/spec2trace" },
         { "t": "remove_files", "file": "/usr/lib/adb/adbgen" },

--- a/image/templates/sled/ramdisk-01-os.json
+++ b/image/templates/sled/ramdisk-01-os.json
@@ -36,6 +36,7 @@
 
         { "t": "pkg_install", "pkgs": [
             "/developer/debug/mdb",
+            "/driver/developer/amd/zen",
             "/system/kernel/dtrace/providers",
             "/system/network",
             "/system/microcode/oxide",
@@ -111,18 +112,12 @@
             "/driver/network/opte@${optever}"
         ] },
 
-        { "t": "pkg_install", "with": "mbist", "pkgs": [
-            "/driver/developer/amd/zen"
-        ] },
-
         { "t": "pkg_install", "with": "mfg", "pkgs": [
-            "/driver/developer/amd/zen",
             "/driver/cpu/amd/psp",
             "/driver/developer/amd/psp/einj"
         ] },
 
         { "t": "pkg_install", "with": "compliance", "pkgs": [
-            "/driver/developer/amd/zen",
             "/driver/cpu/amd/psp",
             "/driver/developer/amd/psp/einj",
             "/developer/debug/humility"


### PR DESCRIPTION
We could do with access to tools such as `uhsmp` in production images to help with fault analysis and we don't currently install `developer/amd/zen` outside of racktest, mbist and compliance.
Add the package to all image types, and strip it back out of the recovery/installinator image.