### PR TITLE
install phbl's toolchain during helios-build setup

### DIFF
--- a/config/projects.toml
+++ b/config/projects.toml
@@ -29,6 +29,7 @@ cargo_build = true
 [project.phbl]
 github = "oxidecomputer/phbl"
 use_ssh = false
+cargo_toolchain = true
 auto_update = true
 
 [project.image-builder]

--- a/tools/helios-build/src/main.rs
+++ b/tools/helios-build/src/main.rs
@@ -239,6 +239,12 @@ struct Project {
     cargo_build: bool,
     #[serde(default)]
     use_debug: bool,
+    /*
+     * If `cargo_build` is false, still install the Rust toolchain required by
+     * this project:
+     */
+    #[serde(default)]
+    cargo_toolchain: bool,
 
     /*
      * If this environment variable is set to "no", we will skip cloning and
@@ -1976,7 +1982,6 @@ fn cmd_image(ca: &CommandArg) -> Result<()> {
     info!(log, "creating reset image...");
     let phbl_path = top_path(&["projects", "phbl"])?;
     let phbl_target = rel_path(Some(&outdir), &["phbl"])?;
-    rustup_install_toolchain(log, &phbl_path)?;
     ensure::run_in(
         log,
         &phbl_path,
@@ -1998,7 +2003,6 @@ fn cmd_image(ca: &CommandArg) -> Result<()> {
     )?;
 
     let ahib_path = top_path(&["projects", "amd-host-image-builder"])?;
-    rustup_install_toolchain(log, &ahib_path)?;
 
     /*
      * Go through and create the per-board ROM images.
@@ -2586,13 +2590,18 @@ fn cmd_setup(ca: &CommandArg) -> Result<()> {
     /*
      * Perform setup in project repositories that require it.
      */
-    for (name, project) in p.project.iter().filter(|p| p.1.cargo_build) {
+    for (name, project) in &p.project {
         if project.skip() {
             continue;
         }
 
         let path = top_path(&["projects", &name])?;
-        rustup_install_toolchain(log, &path)?;
+        if project.cargo_toolchain || project.cargo_build {
+            rustup_install_toolchain(log, &path)?;
+        }
+        if !project.cargo_build {
+            continue;
+        }
 
         info!(log, "building project {:?} at {}", name, path.display());
         let start = Instant::now();


### PR DESCRIPTION
This aims to solve https://github.com/oxidecomputer/omicron/issues/10499.

Omicron releng runs what it can in parallel, including the host and recovery OS images. phbl does not have `cargo_build = true` set, because it needs to be compiled in a particular way using its xtask. Thus the toolchain is not installed until the time at which phbl is invoked during the image build.

rustup cannot be safely used in parallel. A recent set of changes to rustup to make it more parallel/faster has exacerbated this problem. Every now and then the two tasks will align such that both the host and recovery builds are trying to install the phbl toolchain simultaneously, which explodes.

This adds a `cargo_toolchain` flag for projects and sets it for phbl, ensuring that the toolchain is installed during setup.

Omicron's `cargo xtask releng` runs fine in local testing with this change.