### PR TITLE
recovery-elide-v3.json: pcieb is no more

### DIFF
--- a/image/templates/include/recovery-elide-v3.json
+++ b/image/templates/include/recovery-elide-v3.json
@@ -818,7 +818,6 @@
         { "t": "remove_files", "file": "/usr/lib/link_audit/who.so.1" },
         { "t": "remove_files", "file": "/usr/lib/pci/pcidb" },
         { "t": "remove_files", "file": "/usr/lib/pci/pcidr_plugin.so" },
-        { "t": "remove_files", "file": "/usr/lib/pci/pcieb" },
         { "t": "remove_files", "file": "/usr/lib/raidcfg/amd64/mpt.so.1" },
         { "t": "remove_files", "file": "/usr/lib/raidcfg/mpt.so.1" },
         { "t": "remove_files", "file": "/usr/lib/reparse/libreparse_smb.so.1" },


### PR DESCRIPTION
https://github.com/oxidecomputer/illumos-gate/commit/7f6e8bd2af099481941273422899d810c8e91eec folds /usr/lib/pci/pcieb into pcieadm. This unfortunately broke recovery-elide-v3.json.

Merging this should fix Omicron CI (it fixes it in local testing).

In the future we might consider having `remove_files` use `rm -f` to succeed even if the file is not there but I don't know if that's the right choice.