### PR TITLE
Ship GN-PMFW_45_104_100

### DIFF
--- a/image/amd/milan-gimlet-b-1.0.0.f.toml
+++ b/image/amd/milan-gimlet-b-1.0.0.f.toml
@@ -1,20 +1,20 @@
 cpu = 'milan'
 board = 'gimlet-b'
-firmware_version = '1.0.0.h'
+firmware_version = '1.0.0.f'
 size = 32
 blobs = [
     'AmdPubKey_gn.tkn',
     'PspBootLoader_gn.sbin',
     'PspRecoveryBootLoader_gn.sbin',
-    'SmuFirmwareGn.csbin',
+    'SmuFirmwareGn-45-104-100.csbin',
     'SecureDebugToken_gn.stkn',
     'PspABLFw_gn.stkn',
-    'SmuFirmware2Gn.csbin',
+    'SmuFirmware2Gn-45-104-100.csbin',
     'SecureDebugUnlock_gn.sbin',
     'PspIkek_gn.bin',
     'SecureEmptyToken.bin',
     'RsmuSecPolicy_gn.sbin',
-    'Mp5Gn.csbin',
+    'Mp5Gn-45-104-100.csbin',
     'AgesaBootloader_U_prod_GN.csbin',
     'GnPhyFw.sbin',
     'PSP-Key-DB_gn.sbin',

--- a/image/amd/milan-gimlet-b.efs.json5
+++ b/image/amd/milan-gimlet-b.efs.json5
@@ -34,7 +34,7 @@
         },
         {
           source: {
-            BlobFile: "SmuFirmwareGn.csbin"
+            BlobFile: "SmuFirmwareGn-45-104-100.csbin"
           },
           target: {
             type: "SmuOffChipFirmware8"
@@ -70,7 +70,7 @@
         },
         {
           source: {
-            BlobFile: "SmuFirmware2Gn.csbin"
+            BlobFile: "SmuFirmware2Gn-45-104-100.csbin"
           },
           target: {
             type: "SmuOffChipFirmware12"
@@ -110,7 +110,7 @@
         },
         {
           source: {
-            BlobFile: "Mp5Gn.csbin"
+            BlobFile: "Mp5Gn-45-104-100.csbin"
           },
           target: {
             type: "Mp5Firmware"

--- a/image/templates/sled/targets.toml
+++ b/image/templates/sled/targets.toml
@@ -1,6 +1,6 @@
 [gimlet]
 efs = "milan-gimlet-b.efs.json5"
-app = "milan-gimlet-b-1.0.0.h.toml"
+app = "milan-gimlet-b-1.0.0.f.toml"
 
 [cosmo]
 efs = "turin-cosmo-a.efs.json5"


### PR DESCRIPTION
Building a gimlet image with this change resulted in the updated 45.104.100 firmware being pulled in:

```
Jul 02 17:04:08.570 INFO E| Running `target/debug/amd-host-image-builder generate -v -s 32MiB -r /home/andy/out/phbl/x86_64-oxide-none-elf/release/phbl -c /home/andy/helios/image/amd/milan-gimlet-b.efs.json5 -B /home/andy/helios/projects/amd-firmware/GN/1.0.0.f -o /home/andy/out/gimlet.rom`
Jul 02 17:04:08.756 INFO E| Info: Using blob "/home/andy/helios/projects/amd-firmware/GN/1.0.0.f/AmdPubKey_gn.tkn"
Jul 02 17:04:08.756 INFO E| Info: Using blob "/home/andy/helios/projects/amd-firmware/GN/1.0.0.f/PspBootLoader_gn.sbin"
Jul 02 17:04:08.756 INFO E| Info: Using blob "/home/andy/helios/projects/amd-firmware/GN/1.0.0.f/PspRecoveryBootLoader_gn.sbin"
Jul 02 17:04:08.756 INFO E| Info: Using blob "/home/andy/helios/projects/amd-firmware/GN/1.0.0.f/SmuFirmwareGn-45-104-100.csbin"
Jul 02 17:04:08.756 INFO E| Info: Using blob "/home/andy/helios/projects/amd-firmware/GN/1.0.0.f/SecureDebugToken_gn.stkn"
Jul 02 17:04:08.757 INFO E| Info: Using blob "/home/andy/helios/projects/amd-firmware/GN/1.0.0.f/PspABLFw_gn.stkn"
Jul 02 17:04:08.757 INFO E| Info: Using blob "/home/andy/helios/projects/amd-firmware/GN/1.0.0.f/SmuFirmware2Gn-45-104-100.csbin"
Jul 02 17:04:08.757 INFO E| Info: Using blob "/home/andy/helios/projects/amd-firmware/GN/1.0.0.f/SecureDebugUnlock_gn.sbin"
Jul 02 17:04:08.757 INFO E| Info: Using blob "/home/andy/helios/projects/amd-firmware/GN/1.0.0.f/PspIkek_gn.bin"
Jul 02 17:04:08.757 INFO E| Info: Using blob "/home/andy/helios/projects/amd-firmware/GN/1.0.0.f/SecureEmptyToken.bin"
Jul 02 17:04:08.757 INFO E| Info: Using blob "/home/andy/helios/projects/amd-firmware/GN/1.0.0.f/RsmuSecPolicy_gn.sbin"
Jul 02 17:04:08.757 INFO E| Info: Using blob "/home/andy/helios/projects/amd-firmware/GN/1.0.0.f/Mp5Gn-45-104-100.csbin"
Jul 02 17:04:08.757 INFO E| Info: Using blob "/home/andy/helios/projects/amd-firmware/GN/1.0.0.f/AgesaBootloader_U_prod_GN.csbin"
Jul 02 17:04:08.757 INFO E| Info: Using blob "/home/andy/helios/projects/amd-firmware/GN/1.0.0.f/GnPhyFw.sbin"
Jul 02 17:04:08.757 INFO E| Info: Using blob "/home/andy/helios/projects/amd-firmware/GN/1.0.0.f/PSP-Key-DB_gn.sbin"
Jul 02 17:04:08.757 INFO O| Info: ABL version: 0x100f5010
Jul 02 17:04:08.757 INFO O| Info: For sub_program 0: SMU firmware version: 45.104.100
```