### PR TITLE
bump ramdisk to 1200MB

### DIFF
--- a/image/templates/sled/zfs.json
+++ b/image/templates/sled/zfs.json
@@ -4,7 +4,7 @@
         "bename": "ramdisk",
         "ashift": 9,
         "uefi": false,
-        "size": 1050,
+        "size": 1200,
         "label": false,
         "no_features": false,
         "compression": "gzip-9",


### PR DESCRIPTION
We are hitting the ramdisk size on https://github.com/oxidecomputer/omicron/pull/10847. Rust 1.97 seems to have caused a significant increase in Rust binary size:

```
# rust 1.96.1
iliana@atrium ~/omicron $ du -sh out/switch-asic.tar.gz
471M    out/switch-asic.tar.gz
iliana@atrium ~/omicron $ du -sh target/release/sled-agent
57.4M   target/release/sled-agent

# rust 1.97.1
iliana@atrium ~/omicron $ du -sh out/switch-asic.tar.gz
513M    out/switch-asic.tar.gz
iliana@atrium ~/omicron $ du -sh target/release/sled-agent
63.7M   target/release/sled-agent
```

I would like to understand the root cause at some point -- it is perhaps related to the new symbol mangling scheme -- but regardless we are going to want to update the toolchain. The above checks account for a 50 MiB (compressed) increase and I know there's many more Rust binaries in the host OS image than that, so 1200 seems safe to account for wanting to do a mass-upgrade to 1.97.1 across what we ship.