### PR TITLE
image: add os_rot driver

### DIFF
--- a/image/templates/sled/ramdisk-01-os.json
+++ b/image/templates/sled/ramdisk-01-os.json
@@ -90,6 +90,8 @@
 
             "oxide/platform-identity-cacerts",
 
+            "/driver/oxide/os-rot",
+
             "${@extra_packages}"
         ] },
 


### PR DESCRIPTION
Add the `os_rot` driver and DPE framework introduced in https://github.com/oxidecomputer/stlouis/issues/812.