### PR TITLE
Do not ship driver/developer/amd/zen in all images

### DIFF
--- a/image/templates/include/recovery-elide-v3.json
+++ b/image/templates/include/recovery-elide-v3.json
@@ -481,10 +481,6 @@
         { "t": "remove_files", "file": "/usr/has/bin/vi" },
         { "t": "remove_files", "file": "/usr/has/bin/view" },
 
-        { "t": "remove_files", "file": "/kernel/drv/amd64/uhsmp" },
-        { "t": "remove_files", "file": "/kernel/drv/amd64/usmn" },
-        { "t": "remove_files", "file": "/kernel/drv/amd64/zen_udf" },
-
         { "t": "remove_files", "file": "/usr/kernel/drv/amd64/logindmux" },
         { "t": "remove_files", "file": "/usr/kernel/drv/amd64/pool" },
         { "t": "remove_files", "file": "/usr/kernel/drv/amd64/ppt" },
@@ -518,10 +514,6 @@
 
         { "t": "remove_files", "file": "/usr/kvm/README" },
 
-        { "t": "remove_files", "file": "/usr/lib/apobdump" },
-        { "t": "remove_files", "file": "/usr/lib/udf" },
-        { "t": "remove_files", "file": "/usr/lib/uhsmp" },
-        { "t": "remove_files", "file": "/usr/lib/usmn" },
         { "t": "remove_files", "file": "/usr/lib/abi/spec2map" },
         { "t": "remove_files", "file": "/usr/lib/abi/spec2trace" },
         { "t": "remove_files", "file": "/usr/lib/adb/adbgen" },

--- a/image/templates/sled/ramdisk-01-os.json
+++ b/image/templates/sled/ramdisk-01-os.json
@@ -36,7 +36,6 @@
 
         { "t": "pkg_install", "pkgs": [
             "/developer/debug/mdb",
-            "/driver/developer/amd/zen",
             "/system/kernel/dtrace/providers",
             "/system/network",
             "/system/microcode/oxide",
@@ -112,12 +111,18 @@
             "/driver/network/opte@${optever}"
         ] },
 
+        { "t": "pkg_install", "with": "mbist", "pkgs": [
+            "/driver/developer/amd/zen"
+        ] },
+
         { "t": "pkg_install", "with": "mfg", "pkgs": [
+            "/driver/developer/amd/zen",
             "/driver/cpu/amd/psp",
             "/driver/developer/amd/psp/einj"
         ] },
 
         { "t": "pkg_install", "with": "compliance", "pkgs": [
+            "/driver/developer/amd/zen",
             "/driver/cpu/amd/psp",
             "/driver/developer/amd/psp/einj",
             "/developer/debug/humility"


### PR DESCRIPTION
Now that we have a `libhsmp` and accompanying `hsmp` CLI utililty, we no longer need to ship the `developer/amd/zen` package in production images. This was done temporarily to assist with diagnosing various issues with CPU frequency collapse.